### PR TITLE
organize sidebar

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,14 +2,14 @@
 
 - [Introduction](README.md)
 - [Initial Network State](initial-network-state.md)
-- [Staking](staking.md)
-- [Bonds](bonds.md)
 - [Policy](policy.md)
 - [Market Dynamics](market-dynamics.md)
 
-## FAQ
+## Basics
 
-- [Basics](faqs/basics.md)
+- [FAQ](faqs/basics.md)
+- [Staking](staking.md)
+- [Bonds](bonds.md)
 
 ## Using the Website
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,16 +1,11 @@
 # Table of contents
 
 - [Introduction](README.md)
+- [Initial Network State](initial-network-state.md)
 - [Staking](staking.md)
 - [Bonds](bonds.md)
 - [Policy](policy.md)
-- [Initial Network State](initial-network-state.md)
 - [Market Dynamics](market-dynamics.md)
-- [Architecture](architecture.md)
-- [Contracts](contracts.md)
-- [Equations](equations.md)
-- [Glossary](glossary.md)
-- [Translations](translations.md)
 
 ## FAQ
 
@@ -20,3 +15,11 @@
 
 - [Staking](using-the-website/staking.md)
 - [Bonds](using-the-website/bonds.md)
+
+## References
+
+- [Architecture](architecture.md)
+- [Contracts](contracts.md)
+- [Equations](equations.md)
+- [Glossary](glossary.md)
+- [Translations](translations.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,8 +13,8 @@
 
 ## Using the Website
 
-- [Staking](using-the-website/staking.md)
-- [Bonds](using-the-website/bonds.md)
+- [Stake Your OHM (3, 3)](using-the-website/staking.md)
+- [Purchase A Bond (1, 1)](using-the-website/bonds.md)
 
 ## References
 


### PR DESCRIPTION
I would like us to discuss how the sidebar in the docs could evolve. I am not sure what is right or wrong so I would appreciate your input. One thing that I do not like that much is that we have staking and bonds pages twice. One for explaining the general concept and one for using the website. The current suggestion looks something like this.

---

<img width="313" alt="Screenshot 2021-05-08 at 13 34 55" src="https://user-images.githubusercontent.com/552769/117537562-2f01c380-b002-11eb-8b1d-506afe0b42b2.png">
