### PR TITLE
remove ICV since it does not exist anymore

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -38,13 +38,6 @@ smart contracts live. At any given block in the chain, Ethereum has one and only
 one canonical state, and the EVM is what defines the rules for computing a new
 valid state from block to block.
 
-### ICV
-
-Inflation Control Variable, is the scaling factor at which protocol defined sell
-pressure changes. A higher ICV means more sell pressure from the protocol,
-resulting in a higher inflation. A lower ICV means less sell pressure from the
-protocol, resulting in a lower inflation.
-
 ### Liquidity Bonds
 
 Liquidity bonds are LP token bonds. Examples are OHM-DAI LP bonds and OHM-FRAX

--- a/policy.md
+++ b/policy.md
@@ -4,9 +4,9 @@ Olympus features policy constants that allow us to optimize the system.
 
 ## Bonds
 
-The **BCV** allows us to scale the rate at which bond premiums increase. A higher BCV means a lower discount for bonders and less inflation. A lower BCV means a higher capacity for bonders and less protocol profit.
+The **BCV** allows us to scale the rate at which bond premiums increase. A higher BCV means a lower discount for bonders and more protocol profit. A lower BCV means a higher discount for bonders and less protocol profit.
 
-The **vesting term** determines how long it takes for bonds to become redeemable. A longer term means lower inflation and lower bond demand.
+The **vesting term** determines how long it takes for bonds to become fully redeemable. A longer term means lower inflation and lower bond demand.
 
 ## Sales
 

--- a/policy.md
+++ b/policy.md
@@ -1,20 +1,16 @@
 # Policy
 
-Olympus features policy constants that allow us to optimize the system. 
+Olympus features policy constants that allow us to optimize the system.
 
 ## Bonds
 
 The **BCV** allows us to scale the rate at which bond premiums increase. A higher BCV means a lower discount for bonders and less inflation. A lower BCV means a higher capacity for bonders and less protocol profit.
 
-The **vesting term** determines how long it takes for bonds to become redeemable. A longer term means lower inflation and lower bond demand. 
+The **vesting term** determines how long it takes for bonds to become redeemable. A longer term means lower inflation and lower bond demand.
 
 ## Sales
 
-The **ICV** allows us to scale protocol sell pressure up or down. A higher ICV means more sell pressure and higher inflation. A lower ICV means less sell pressure and lower profitability.
-
 The **DCV** allows us to scale protocol buy pressure up or down. A higher DCV means more buy pressure and higher deflation. A lower DCV means less buy pressure and a weaker floor.
-
-The **discount rate** determines the arbitrage available to execute protocol market orders. A higher discount means greater incentive to fill the protocol's order but lower profitability.
 
 ## Treasury
 
@@ -23,8 +19,3 @@ Profit Allocations are the only treasury variable. This allows us to choose who 
 ## Staking
 
 There are no variables in the staking contract. OHM and sOHM are always redeemable 1:1, and profits are always distributed equally through rebase.
-
-
-
-
-


### PR DESCRIPTION
Sh4dow gave a notice that ICV does not exist anymore. I believe it got removed/deactivated with SalesLite, but that assumption should be confirmed. I just drop the ICV and discount rate terms since they appear to be obsolete now. 